### PR TITLE
Add Getting Company Profile by ISIN or CUSIP

### DIFF
--- a/src/ThreeFourteen.Finnhub.Client.Runner/Program.cs
+++ b/src/ThreeFourteen.Finnhub.Client.Runner/Program.cs
@@ -36,6 +36,12 @@ namespace ThreeFourteen.Finnhub.Client.Runner
             var company = await client.Stock.GetCompany("AAPL");
             Console.WriteLine($"Success: Retrieved company {company.Name}.");
 
+            var company2 = await client.Stock.GetCompanyByIsin("US0378331005"); // AAPL
+            Console.WriteLine($"Success: Retrieved company {company.Name}.");
+
+            var company3 = await client.Stock.GetCompanyByCusip("037833100"); // AAPL
+            Console.WriteLine($"Success: Retrieved company {company.Name}.");
+
             var compensation = await client.Stock.GetCompensation("AAPL");
             Console.WriteLine($"Success: Retrieved compensation for {compensation.Name} ({compensation.CompanyName}).");
 

--- a/src/ThreeFourteen.Finnhub.Client/FieldKeys.cs
+++ b/src/ThreeFourteen.Finnhub.Client/FieldKeys.cs
@@ -10,5 +10,7 @@
         public const string Exchange = "exchange";
         public const string Category = "category";
         public const string MinId = "minId";
+        public const string Isin = "isin";
+        public const string Cusip = "cusip";
     }
 }

--- a/src/ThreeFourteen.Finnhub.Client/StockClient.cs
+++ b/src/ThreeFourteen.Finnhub.Client/StockClient.cs
@@ -22,6 +22,22 @@ namespace ThreeFourteen.Finnhub.Client
                 new Field(FieldKeys.Symbol, symbol));
         }
 
+        public Task<Company> GetCompanyByIsin(string isin)
+        {
+            if (string.IsNullOrWhiteSpace(isin)) throw new ArgumentException(nameof(isin));
+
+            return _finnhubClient.SendAsync<Company>("stock/profile", JsonDeserialiser.Default,
+                new Field(FieldKeys.Isin, isin));
+        }
+
+        public Task<Company> GetCompanyByCusip(string cusip)
+        {
+            if (string.IsNullOrWhiteSpace(cusip)) throw new ArgumentException(nameof(cusip));
+
+            return _finnhubClient.SendAsync<Company>("stock/profile", JsonDeserialiser.Default,
+                new Field(FieldKeys.Cusip, cusip));
+        }
+
         public Task<Compensation> GetCompensation(string symbol)
         {
             if (string.IsNullOrWhiteSpace(symbol)) throw new ArgumentException(nameof(symbol));

--- a/test/ThreeFourteen.Finnhub.Client.Tests/Stocks.cs
+++ b/test/ThreeFourteen.Finnhub.Client.Tests/Stocks.cs
@@ -27,6 +27,40 @@ namespace ThreeFourteen.Finnhub.Client.Tests
         }
 
         [Fact]
+        public async Task CompanyByIsin()
+        {
+            var httpClientTester = new HttpClientTester()
+                .SetResponseContent(DataLoader.LoadStock("company"));
+
+            var client = new FinnhubClient(httpClientTester.Client, "APIKey");
+
+            var company = await client.Stock.GetCompanyByIsin("US0378331005");
+
+            company.Should().NotBeNull();
+            company.Address.Should().Be("One Apple Park Way");
+
+            httpClientTester.RequestMessage.RequestUri
+                .AbsoluteUri.Should().Be("https://finnhub.io/api/v1/stock/profile?token=APIKey&isin=US0378331005");
+        }
+
+        [Fact]
+        public async Task CompanyByCusip()
+        {
+            var httpClientTester = new HttpClientTester()
+                .SetResponseContent(DataLoader.LoadStock("company"));
+
+            var client = new FinnhubClient(httpClientTester.Client, "APIKey");
+
+            var company = await client.Stock.GetCompanyByCusip("037833100");
+
+            company.Should().NotBeNull();
+            company.Address.Should().Be("One Apple Park Way");
+
+            httpClientTester.RequestMessage.RequestUri
+                .AbsoluteUri.Should().Be("https://finnhub.io/api/v1/stock/profile?token=APIKey&cusip=037833100");
+        }
+
+        [Fact]
         public async Task Compensation()
         {
             var httpClientTester = new HttpClientTester()


### PR DESCRIPTION
The Finnhub API provides the possibility to not only get the company profile by symbol, but by ISIN and CUSIP too. This enables

* better interopability with other services
* converting from ISIN -> symbol, etc.

This is important in some use cases, as these symbols aren't universal if compared by machines. I.e. one service uses "BRK.B" and another one (like Finnhub) uses "BRK-B".

I hope I found all places that need adjustment to deliver this change. Feel free to comment if I should change/improve/... anything.