### PR TITLE
Fix Timezone Dependency of Test Candles_WithRange

### DIFF
--- a/test/ThreeFourteen.Finnhub.Client.Tests/Stocks.cs
+++ b/test/ThreeFourteen.Finnhub.Client.Tests/Stocks.cs
@@ -205,7 +205,7 @@ namespace ThreeFourteen.Finnhub.Client.Tests
 
             var client = new FinnhubClient(httpClientTester.Client, "APIKey");
 
-            var candles = await client.Stock.GetCandles("AAPL", Resolution.FiveMinutes, DateTime.Parse("2019/12/1"), DateTime.Parse("2019/12/2"));
+            var candles = await client.Stock.GetCandles("AAPL", Resolution.FiveMinutes, new DateTimeOffset(2019, 12, 1, 0, 0, 0, TimeSpan.Zero).UtcDateTime, new DateTimeOffset(2019, 12, 2, 0, 0, 0, TimeSpan.Zero).UtcDateTime);
 
             candles.Should().NotBeNull();
             candles.Should().HaveCount(3);


### PR DESCRIPTION
While I did not change any code in that path, the test `Candles_WithRange` fails when I run the test cases on my machine, because the URI doen't match:

```
Expected string to be 
    "https://finnhub.io/api/v1/stock/candle?token=Token&symbol=AAPL&resolution=5&from=1575158400&to=1575244800", but 
    "https://finnhub.io/api/v1/stock/candle?token=Token&symbol=AAPL&resolution=5&from=1575151200&to=1575237600" differs near "120" (index 102).
```

Root of the problem is that line

    var candles = await client.Stock.GetCandles("AAPL", Resolution.FiveMinutes, DateTime.Parse("2019/12/1"), DateTime.Parse("2019/12/2"));

works as the test expects when your computer's time equals UTC, which yours probably does but mine does not.